### PR TITLE
Add helper functionalities

### DIFF
--- a/src/Back.jsx
+++ b/src/Back.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+
+const Back = ({ children, ...props }, context) => {
+  return (
+    <a {...props} onClick={() => context.location.back()}>
+      {children}
+    </a>
+  );
+};
+
+Back.contextTypes = {
+  location: PropTypes.shape({
+    back: PropTypes.func
+  })
+};
+
+Back.propTypes = {
+  children: PropTypes.node.isRequired
+};
+
+
+export default Back;

--- a/src/FourOhFour.jsx
+++ b/src/FourOhFour.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+
+export default () => {
+  return (
+    <div style={{
+      position: 'absolute',
+      textAlign: 'center',
+      top: '45vh',
+      width: '100vw'
+    }}>
+      <h2>404!</h2>
+      <h3>Page not found</h3>
+    </div>
+  )
+}

--- a/src/FourOhFour.jsx
+++ b/src/FourOhFour.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Back from './Back';
 
 
 export default () => {
@@ -11,6 +12,17 @@ export default () => {
     }}>
       <h2>404!</h2>
       <h3>Page not found</h3>
+      <br />
+      <Back
+        style={{
+          color: '#fff',
+          cursor: 'pointer',
+          padding: '10px 20px',
+          backgroundColor: '#333'
+        }}
+      >
+        Go Back
+      </Back>
     </div>
   )
 }

--- a/src/Link.jsx
+++ b/src/Link.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+
+const Link = ({ children, href,...props}, context) => {
+  return (
+    <a {...props} onClick={() => context.location.push(href)}>
+      {children}
+    </a>
+  );
+};
+
+Link.contextTypes = {
+  location: PropTypes.shape({
+    push: PropTypes.func,
+    path: PropTypes.string,
+  })
+};
+
+Link.propTypes = {
+  href: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired
+};
+
+export default Link;

--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import { getParams } from './util';
+import fourOhFourPage from './FourOhFour';
 
 /**
  * Routes component. responsible fo rmatching active route to the right component
@@ -43,6 +44,10 @@ const Routes = (props, context) => {
 
   // IF no route was matched, return 404
   if (!activeRoute.length) {
+    if (!fourOhFour) {
+      // default 404 page
+      return fourOhFourPage();
+    }
     return fourOhFour[1](routeProps);
   }
 

--- a/src/__tests__/Back.spec.js
+++ b/src/__tests__/Back.spec.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import { shallow } from 'enzyme';
+
+import Back from '../Back';
+
+
+describe('Back', () => {
+    describe('Snapshot Test', () => {
+        it('renders a link', () => {
+            const tree = renderer.create(
+                <Back>Button</Back>
+            ).toJSON();
+            expect(tree).toMatchSnapshot();
+        });
+    });
+
+    describe('Unit Test', () => {
+        it('should change context on click', () => {
+            let count = 0;
+            const wrapper = shallow(Back(
+                { children: 'Button' },
+                { location: { back: () => count++}}
+            ));
+
+            wrapper.simulate('click');
+
+            expect(count).toEqual(1);
+            expect(wrapper.text()).toEqual('Button');
+        })
+    });
+});

--- a/src/__tests__/Link.spec.js
+++ b/src/__tests__/Link.spec.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import { shallow } from 'enzyme';
+
+import Link from '../Link';
+
+
+describe('Link', () => {
+    describe('Snapshot Test', () => {
+        it('renders a link', () => {
+            const tree = renderer.create(
+                <Link href="/button">Button</Link>
+            ).toJSON();
+            expect(tree).toMatchSnapshot();
+        });
+    });
+
+    describe('Unit Test', () => {
+        it('should change context on click', () => {
+            let count = 0;
+            const wrapper = shallow(Link(
+                { children: 'Button', href: '/button' },
+                { location: { push: () => count++}}
+            ));
+
+            wrapper.simulate('click');
+
+            expect(count).toEqual(1);
+        })
+    });
+});

--- a/src/__tests__/Routes.spec.js
+++ b/src/__tests__/Routes.spec.js
@@ -57,6 +57,18 @@ describe('Routes', () => {
       expect(wrapper.find('h3').text()).toEqual('About me');
     });
 
+    it('should return a default 404 page if a route is not found', () => {
+      window.history.pushState(null, '', '/about/me');
+      let wrapper = mount(<Router render={() => {
+          return <Routes routes={() => (
+            [
+              ['/', () => <h3>Home</h3>],
+            ]
+          )} />
+        }} />);
+      expect(wrapper.find('h2').text()).toEqual('404!');
+    });
+
     it('should return a 404 page if a route is not found', () => {
       window.history.pushState(null, '', '/about/me');
       let wrapper = mount(<Router render={() => {

--- a/src/__tests__/__snapshots__/Back.spec.js.snap
+++ b/src/__tests__/__snapshots__/Back.spec.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Back Snapshot Test renders a link 1`] = `
+<a
+  onClick={[Function]}
+>
+  Button
+</a>
+`;

--- a/src/__tests__/__snapshots__/Link.spec.js.snap
+++ b/src/__tests__/__snapshots__/Link.spec.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Link Snapshot Test renders a link 1`] = `
+<a
+  onClick={[Function]}
+>
+  Button
+</a>
+`;


### PR DESCRIPTION
### What does this PR do?
This PR adds helper functionalities like Link tag, Back tag and default 404 page.

### Description of task to be completed
It has been decided by whoever is in my head that it'll be helpful if users could you internal routing as opposed to `anchor` tag. Also, a component to go back might be handful. And finally, a damn ugly 404 page to inspire people to make beurifful(yes) 404 pages!

### Any Background context?
N/A

### Screenshot(s)
N/A

### Related github issue(s)
N/A