### PR TITLE
Fix class component definition in routes

### DIFF
--- a/build/App.jsx
+++ b/build/App.jsx
@@ -3,6 +3,8 @@ import React from 'react';
 import Link from '../src/Link';
 import Back from '../src/Back';
 import Router from '../src/Router';
+import Express from './Express';
+
 import Routes from '../src/Routes';
 
 
@@ -37,6 +39,7 @@ export const Index = (props) => {
       <Link style={style.link} href="/article/5?title=Route Easy">Route Easy</Link>
       <br/><br />
       <button onClick={() => props.location.push('/about')}>About US</button>
+      <button onClick={() => props.location.push('/class')}>Express</button>
     </div>
   );
 };
@@ -63,7 +66,7 @@ export const User = (props) => {
   );
 }
 
-const App = (props) => {
+export const App = (props) => {
   return (
     <div>
       <h2 onClick={() => props.push('/')}>Home</h2>
@@ -72,14 +75,16 @@ const App = (props) => {
           ['/', Index],
           ['/about', About],
           ['/article/:id', Article],
-          ['/user/:id', User]
+          ['/user/:id', User],
+          ['/class', Express]
         ]
       }}/>
     </div>
   );
 };
 
-
 export default () => {
   return (<Router render={App}/>);
 };
+
+

--- a/build/Express.jsx
+++ b/build/Express.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import Back from '../src/Back';
+
+const style = {
+  link: {
+    color: 'green',
+    padding: 5,
+    textDecoration: 'underline'
+  },
+  container: {
+    textAlign: 'center'
+  }
+};
+export default class Express extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      title: ''
+    }
+  }
+  render() {
+    return (
+      <div>
+        <h2>this is a class component</h2>
+        <Back style={style.link}>Back</Back>
+        <button onClick={() => this.props.location.back()}>Back</button>
+      </div>
+    )
+  }
+}

--- a/src/Back.jsx
+++ b/src/Back.jsx
@@ -5,6 +5,7 @@ import defaultStyle from './style';
 
 
 const Back = ({ children, style, ...props }, context) => {
+  
   const linkStyle = { ...defaultStyle, ...style };
 
   return (

--- a/src/Router.jsx
+++ b/src/Router.jsx
@@ -57,6 +57,7 @@ class Router extends React.Component {
       query: pickQuery(path)
     } });
     History.push(History.state(), '', path);
+
   }
 
   /**

--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -57,7 +57,6 @@ const Routes = (props, context) => {
   // Set route params, if param symbol ":" is present in route,
   // set the parameter to the variable declared above;
   routeProps.location.params = activeRoute[0][0].match(':') ? routeParams : {};
-
   if (!isCallableCheck(Component)) {
     return <Component { ...routeProps} />
   }

--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -1,5 +1,6 @@
+import React from 'react';
 import PropTypes from 'prop-types';
-import { getParams } from './util';
+import { getParams, isCallableCheck } from './util';
 import fourOhFourPage from './FourOhFour';
 
 /**
@@ -11,10 +12,8 @@ import fourOhFourPage from './FourOhFour';
 const Routes = (props, context) => {
   // Get current path;
   const path = context.location.path;
-
   let routeParams;
   let fourOhFour;
-
   // Loop through each individual route
   const activeRoute = props.routes(path).filter((route) => {
     // If the current route is a wildcard, set the 404 page to
@@ -52,12 +51,16 @@ const Routes = (props, context) => {
     return fourOhFour[1](routeProps);
   }
 
-  // const Component = activeRoute[0][1];
+  const Component = activeRoute[0][1];
+  
 
   // Set route params, if param symbol ":" is present in route,
   // set the parameter to the variable declared above;
   routeProps.location.params = activeRoute[0][0].match(':') ? routeParams : {};
-  // return <Component {...routeProps} />;
+
+  if (!isCallableCheck(Component)) {
+    return <Component { ...routeProps} />
+  }
   return activeRoute[0][1](routeProps);
 }
 

--- a/src/__tests__/util.spec.js
+++ b/src/__tests__/util.spec.js
@@ -1,4 +1,4 @@
-import { formatQuery, pickQuery, getParams } from '../util';
+import { formatQuery, pickQuery, getParams, isCallableCheck } from '../util';
 
 
 describe('util', () => {
@@ -25,5 +25,15 @@ describe('util', () => {
     );
     expect(params).toEqual({ id: 'C3PO', name: 'Daisy Ridley' });
     expect(trueRoute).toEqual('/customer/C3PO/name/Daisy Ridley');
+  });
+
+  it('should return a boolean if a function is a callable or constructable', () => {
+    const newFunc = function() {
+    }
+    class newObj {
+    }
+    expect(isCallableCheck(newFunc)).toEqual(true);
+    expect(isCallableCheck(newObj)).toEqual(false);
+    expect(function(){ isCallableCheck(newObj())}).toThrow(new TypeError('Cannot call a class as a function'));
   });
 });

--- a/src/util.js
+++ b/src/util.js
@@ -51,3 +51,18 @@ export const getParams = (activeRoute, path) => {
 
   return { trueRoute, params };
 }
+/**
+ * isCallableCheck - checks if a function is a callable or constructable
+ * and a boolean in the either cases
+ * @export
+ * @param {function} obj 
+ * @returns {boolean}  - returns true or false
+ */
+export function isCallableCheck(obj) {
+  try {
+    obj();
+  } catch (err) {
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
### What does this PR do?
- This PR lets class component be declared in an array like so `['/route', Component]` instead of `['/route', () => <Component />]`.

### How can it be tested?
- Run the build.
- Navigate to `/class` route in the build.

### Description of work done?
 - Create function for checking if a function is a callable or constructable
 - Return a class component like `<Component />`